### PR TITLE
Support microtasks, rendering, and browser tasks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -86,7 +86,7 @@ Usage Example {#example}
 Terminology {#sec-terminology}
 ==============================
 
-<dfn export>Long task</dfn> refers to any of the following tasks whose duration exceeds 50ms:
+<dfn export>Long task</dfn> refers to any of the following occurrences whose duration exceeds 50ms:
 
 * An event loop <a>task</a> plus the <a>perform a microtask checkpoint</a> that follows immediately afterwards. This captures the duration of an event loop <a>task</a>, including its associated <a>microtasks</a>.
 
@@ -116,7 +116,7 @@ Long Task timing involves the following new interfaces:
 
 {{PerformanceLongTaskTiming}} extends the following attributes of {{PerformanceEntry}} interface:
 
-* The {{PerformanceEntry/name}} attribute must return {{DOMString}} that specifies the type of long task being reported. For long tasks obtained from event loop <a>tasks</a>, it also provides minimal frame attribution.
+* The {{PerformanceEntry/name}} attribute must return {{DOMString}} that specifies the type of <a>long task</a> being reported. For long tasks obtained from event loop <a>tasks</a>, it also provides minimal frame attribution.
 
     Possible values for tasks that are not originated from event loop <a>tasks</a> are:
 
@@ -228,21 +228,23 @@ Modifications to other specifications {#mod}
 
 ### HTML: <a>event loop definitions</a> ### {#html-event-loop-dfn}
 
-Each task gets an associated <dfn for="task">script evaluation environment settings object set</dfn>.
+Each <a>task</a> gets an associated <dfn for="task">script evaluation environment settings object set</dfn>.
+
+Each <a>event loop</a> has two associated values: <dfn>event loop begin</dfn> and <dfn>event loop end</dfn>, which are initially unset.
 
 ### HTML: <a>event loop processing model</a> ### {#html-event-loop-processing}
 
 Before Step #1:
 
-* Let |event loop begin| be the <a>current high resolution time</a>.
-* If |event loop end| is set then let |top-level browsing contexts| be the set of all <a>top-level browsing contexts</a> of all <a>Document</a> objects associated with the <a>event loop</a> in question. Execute the [[#report-long-tasks]] algorithm, passing in |event loop begin|, |event loop end|, the string "browser", and |top-level browsing contexts|.
+* Let <a>event loop begin</a> be the <a>current high resolution time</a>.
+* If <a>event loop end</a> is set then let |top-level browsing contexts| be the set of all <a>top-level browsing contexts</a> of all <a>Document</a> objects associated with the <a>event loop</a> in question. Execute the [[#report-long-tasks]] algorithm, passing in <a>event loop begin</a>, <a>event loop end</a>, the string "browser", and |top-level browsing contexts|.
 
 After Step #6:
 
 * Let |task end time| be the <a>current high resolution time</a>.
 * Let |top-level browsing contexts| be an empty set.
 * For each <a>environment settings object</a> |settings| in |oldestTask|'s [=task/script evaluation environment settings object set=], add |settings|'s <a>responsible browsing context</a>'s <a>top-level browsing context</a> to |top-level browsing contexts|.
-* Execute the [[#report-long-tasks]] algorithm, passing in |event loop begin| (repurposed as meaning the beginning of the task), |task end time|, the string "event-loop-task", |top-level browsing contexts|, and |oldestTask|.
+* Execute the [[#report-long-tasks]] algorithm, passing in <a>event loop begin</a> (repurposed as meaning the beginning of the task), |task end time|, the string "event-loop-task", |top-level browsing contexts|, and |oldestTask|.
 
 In Step #7:
 
@@ -256,7 +258,7 @@ After Step #7:
 
 After Step #8 (at the very end):
 
-* Set |event loop end| to be the <a>current high resolution time</a>.
+* Set <a>event loop end</a> to be the <a>current high resolution time</a>.
 
 ### HTML: <a>calling scripts</a> ### {#html-calling-scripts}
 
@@ -312,7 +314,7 @@ Given |start time|, |end time|, |type|, |top-level browsing contexts|, and optio
 
         2. Set |attribution|'s {{PerformanceEntry/entryType}} attribute to <code>"taskattribution"</code>.
         3. Set |attribution|'s {{PerformanceEntry/startTime}} and {{PerformanceEntry/duration}} to 0.
-        4. If |culpritSettings| is not <code>null</code>, and |culpritSettings|'s <a>responsible browsing context</a> has a browsing context container that is an <{iframe}> element, then let |iframe| be that element, and perform the following steps:
+        4. If |culpritSettings| is not <code>null</code>, and |culpritSettings|'s <a>responsible browsing context</a> has a <a>browsing context container</a> that is an <{iframe}> element, then let |iframe| be that element, and perform the following steps:
             1. Set |attribution|'s {{containerName}} attribute to the value of  |iframe|'s <{iframe/name}> content attribute, or <code>null</code> if the attribute is absent.
             2. Set |attribution|'s {{containerSrc}} attribute to the value of |iframe|'s <{iframe/src}> content attribute, or <code>null</code> if the attribute is absent.
 

--- a/index.bs
+++ b/index.bs
@@ -236,8 +236,8 @@ Each <a>event loop</a> has two associated values: <dfn>event loop begin</dfn> an
 
 Before Step #1:
 
-* Let <a>event loop begin</a> be the <a>current high resolution time</a>.
-* If <a>event loop end</a> is set then let |top-level browsing contexts| be the set of all <a>top-level browsing contexts</a> of all <a>Document</a> objects associated with the <a>event loop</a> in question. Execute the [[#report-long-tasks]] algorithm, passing in <a>event loop begin</a>, <a>event loop end</a>, the string "browser", and |top-level browsing contexts|.
+* Set <a>event loop begin</a> to the <a>current high resolution time</a>.
+* If <a>event loop end</a> is set, then let |top-level browsing contexts| be the set of all <a>top-level browsing contexts</a> of all <a>Document</a> objects associated with the <a>event loop</a> in question. Execute the [[#report-long-tasks]] algorithm, passing in <a>event loop begin</a>, <a>event loop end</a>, the string "browser", and |top-level browsing contexts|.
 
 After Step #6:
 

--- a/index.bs
+++ b/index.bs
@@ -29,6 +29,7 @@ urlPrefix: https://w3c.github.io/hr-time/; spec: HR-TIME-2;
     type: interface; url: #dfn-performance; text: Performance;
     type: attribute; for: Performance;
         text: now(); url: #dom-performance-now
+    type: dfn; text: current high resolution time; url: #dfn-current-high-resolution-time;
 urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML;
     type: dfn; url: #definitions-3; text: event loop definitions;
     type: dfn; url: #calling-scripts; text: calling scripts;
@@ -85,7 +86,13 @@ Usage Example {#example}
 Terminology {#sec-terminology}
 ==============================
 
-<dfn export>Long task</dfn> refers to an event loop task that exceeds 50ms.
+<dfn export>Long task</dfn> refers to any of the following tasks whose duration exceeds 50ms:
+
+* An event loop <a>task</a> plus the <a>perform a microtask checkpoint</a> that follows immediately afterwards. This captures the duration of an event loop <a>task</a>, including its associated <a>microtasks</a>.
+
+* An <a>update the rendering</a> step within the <a>event loop processing model</a>.
+
+* A pause between the last step and the next first step of the <a>event loop processing model</a>. This captures any work that the user agent performs in its UI thread outside of the <a>event loop</a>.
 
 <dfn>Frame</dfn> or <dfn>frame context</dfn> refers to the browsing context, such as iframe (not animation frame), embed or object in which some work (such as script or layout) occurs.
 
@@ -96,7 +103,7 @@ Terminology {#sec-terminology}
 Long Task Timing {#sec-longtask-timing}
 =======================================
 
-Long Task timing involves the following new interfaces
+Long Task timing involves the following new interfaces:
 
 {{PerformanceLongTaskTiming}} interface {#sec-PerformanceLongTaskTiming}
 ------------------------------------------------------------------------
@@ -109,7 +116,14 @@ Long Task timing involves the following new interfaces
 
 {{PerformanceLongTaskTiming}} extends the following attributes of {{PerformanceEntry}} interface:
 
-* The {{PerformanceEntry/name}} attribute must return {{DOMString}} for minimal frame attribution. Possible values of name are:
+* The {{PerformanceEntry/name}} attribute must return {{DOMString}} that specifies the type of long task being reported. For long tasks obtained from event loop <a>tasks</a>, it also provides minimal frame attribution.
+
+    Possible values for tasks that are not originated from event loop <a>tasks</a> are:
+
+    * <code>rendering</code>: long task comes from the <a>update the rendering</a> step.
+    * <code>browser</code>: long task comes from work outside of the <a>event loop</a>.
+
+    The following values are only possible for long tasks originated from event loop <a>tasks</a>:
 
     * <code>self</code>: long task is from within my own frame
     * <code>same-origin-ancestor</code>: long task is from a same-origin ancestor frame
@@ -159,12 +173,12 @@ Long Task timing involves the following new interfaces
 Pointing to the culprit {#sec-PointingToCulprit}
 ------------------------------------------------
 
-Long task represents the top level event loop task. Within this task, different types of work (such as script, layout, style etc) may be done, and they could be executed within different frame contexts. The type of work could also be global in nature such as a long GC that is process or frame-tree wide.
+A <a>long task</a> may involve different types of work (such as script, layout, style etc), and it could be executed within different frame contexts or it could be global in nature such as a long GC that is process or frame-tree wide.
 
-Thus pointing to the culprit has couple of facets:
+Thus pointing to the culprit has a couple of facets:
 
-* Pointing to the overall frame to blame for the long task on the whole: this is refered to as "minimal frame attribution" and is captured in the {{PerformanceEntry/name}} field.
-* Pointing to the type of work involved in the task, and its associated frame context: this is captured in {{TaskAttributionTiming}} objects in the {{PerformanceLongTaskTiming/attribution}} field of {{PerformanceLongTaskTiming}}.
+* Pointing to the origin of the long task and/or the overall frame to blame for the long task on the whole: this is referred to as "minimal frame attribution" and is captured in the {{PerformanceEntry/name}} field.
+* Pointing to the type of work involved in the <a>long task</a>, and its associated frame context: this is captured in {{TaskAttributionTiming}} objects in the {{PerformanceLongTaskTiming/attribution}} field of {{PerformanceLongTaskTiming}}.
 
 Therefore, {{PerformanceEntry/name}} and {{PerformanceLongTaskTiming/attribution}} fields on {{PerformanceLongTaskTiming}} together paint the picture for where the blame rests for a long task.
 When delivering this information the web origin-policy must be adhered to.
@@ -214,18 +228,35 @@ Modifications to other specifications {#mod}
 
 ### HTML: <a>event loop definitions</a> ### {#html-event-loop-dfn}
 
-Each task gets an associated <dfn for="task">start time</dfn>, <dfn for="task">end time</dfn>, and <dfn for="task">script evaluation environment settings object set</dfn>.
+Each task gets an associated <dfn for="task">script evaluation environment settings object set</dfn>.
 
 ### HTML: <a>event loop processing model</a> ### {#html-event-loop-processing}
 
-Before Step #3:
+Before Step #1:
 
-* Set the selected |oldestTask|'s [=task/start time=] to be the value that would be returned by the {{Performance}} object's {{Performance/now()}} method.
+* Let |event loop begin| be the <a>current high resolution time</a>.
+* If |event loop end| is set then let |top-level browsing contexts| be the set of all <a>top-level browsing contexts</a> of all <a>Document</a> objects associated with the <a>event loop</a> in question. Execute the [[#report-long-tasks]] algorithm, passing in |event loop begin|, |event loop end|, the string "browser", and |top-level browsing contexts|.
 
-After Step #3:
+After Step #6:
 
-* Set |oldestTask|'s [=task/end time=] to the value be the value that would be returned by the {{Performance}} object's {{Performance/now()}} method.
-* Execute the [[#report-long-tasks]] algorithm, passing in |oldestTask|.
+* Let |task end time| be the <a>current high resolution time</a>.
+* Let |top-level browsing contexts| be an empty set.
+* For each <a>environment settings object</a> |settings| in |oldestTask|'s [=task/script evaluation environment settings object set=], add |settings|'s <a>responsible browsing context</a>'s <a>top-level browsing context</a> to |top-level browsing contexts|.
+* Execute the [[#report-long-tasks]] algorithm, passing in |event loop begin| (repurposed as meaning the beginning of the task), |task end time|, the string "event-loop-task", |top-level browsing contexts|, and |oldestTask|.
+
+In Step #7:
+
+* In substep #1, <var ignore=''>now</var> can be replaced with |task end time|. This saves a call to <a>current high resolution time</a>.
+
+After Step #7:
+
+* Let |rendering end time| be the <a>current high resolution time</a>.
+* Let |top-level browsing contexts| be the set of all <a>top-level browsing context</a> of all <a>fully active</a> <a>Document</a> in <var ignore=''>docs</var>.
+* Execute the [[#report-long-tasks]] algorithm, passing in |task end time| (repurposed as meaning the beginning of the update the rendering step), |rendering end time|, the string "rendering", and |top-level browsing contexts|.
+
+After Step #8 (at the very end):
+
+* Set |event loop end| to be the <a>current high resolution time</a>.
 
 ### HTML: <a>calling scripts</a> ### {#html-calling-scripts}
 
@@ -236,26 +267,26 @@ Additions to the Long Task Spec {#sec-additions-to-spec}
 
 <h4 dfn>Report Long Tasks</h4>
 
-Given a task |task|, perform the following algorithm:
+Given |start time|, |end time|, |type|, |top-level browsing contexts|, and optionally |task|, perform the following algorithm:
 
-1. If |task|'s [=task/end time=] minus [=task/start time=] is less than the long tasks threshold of 50 ms, abort these steps.
+1. If |end time| minus |start time| is less than the long tasks threshold of 50 ms, abort these steps.
 
 2. Let |destinationRealms| be an empty set.
 
 3. Determine the set of <a>JavaScript Realms</a> to which reports will be delivered:
 
-    For each <a>environment settings object</a> |settings| in |task|'s [=task/script evaluation environment settings object set=]:
+    For each <a>top-level browsing context</a> |topmostBC| in |top-level browsing contexts|:
 
-    1. Let |topmostBC| be |settings|'s <a>responsible browsing context</a>'s <a>top-level browsing context</a>.
-    2. Add |topmostBC|'s Window's <a>relevant Realm</a> to |destinationRealms|.
-    3. Let |descendantBCs| be |topmostBC|'s <a>active document</a>'s <a>list of the descendant browsing contexts</a>.
-    4. For each |descendantBC| in |descendantBCs|, add |descendantBC|'s Window's <a>relevant Realm</a> to |destinationRealms|.
+    1. Add |topmostBC|'s Window's <a>relevant Realm</a> to |destinationRealms|.
+    2. Let |descendantBCs| be |topmostBC|'s <a>active document</a>'s <a>list of the descendant browsing contexts</a>.
+    3. For each |descendantBC| in |descendantBCs|, add |descendantBC|'s Window's <a>relevant Realm</a> to |destinationRealms|.
 
 4. For each |destinationRealm| in |destinationRealms|:
 
     1. Let |name| be the empty string. This will be used to report minimal frame attribution, below.
     2. Let |culpritSettings| be <code>null</code>.
-    3. Process |task|'s [=task/script evaluation environment settings object set=] to determine |name| and |culpritSettings| as follows:
+    3. If the |task| argument was not provided, set |name| to |type|.
+    3. Otherwise: assert that |type| equals "event-loop-task" and process |task|'s [=task/script evaluation environment settings object set=] to determine |name| and |culpritSettings| as follows:
 
         1. If |task|'s [=task/script evaluation environment settings object set=] is empty: set |name| to <code>"unknown"</code> and |culpritSettings| to <code>null</code>.
         2. If |task|'s [=task/script evaluation environment settings object set=]'s length is greater than one: set |name| to <code>"multiple-contexts"</code> and |culpritSettings| to <code>null</code>.
@@ -273,30 +304,34 @@ Given a task |task|, perform the following algorithm:
 
                 2. If |culpritSettings|'s <a>responsible browsing context</a> is a descendant of |destinationBC|, set |name| to <code>"cross-origin-descendant"</code>.
 
-5. Create a new {{TaskAttributionTiming}} object |attribution| and set its attributes as follows:
-    1. Set |attribution|'s {{PerformanceEntry/name}} attribute to <code>"script"</code>.
-    2. Set |attribution|'s {{PerformanceEntry/entryType}} attribute to <code>"taskattribution"</code>.
-    3. Set |attribution|'s {{PerformanceEntry/startTime}} and {{PerformanceEntry/duration}} to 0.
-    4. If |culpritSettings| is not <code>null</code>, and |culpritSettings|'s <a>responsible browsing context</a> has a browsing context container that is an <{iframe}> element, then let |iframe| be that element, and perform the following steps:
-        1. Set |attribution|'s {{containerName}} attribute to the value of  |iframe|'s <{iframe/name}> content attribute, or <code>null</code> if the attribute is absent.
-        2. Set |attribution|'s {{containerSrc}} attribute to the value of |iframe|'s <{iframe/src}> content attribute, or <code>null</code> if the attribute is absent.
+    4. If |task| was not provided, let |attribution| be <code>null</code>.
+    5. Otherwise, let |attribution| be a new {{TaskAttributionTiming}} object |attribution| and set its attributes as follows:
+        1. Set |attribution|'s {{PerformanceEntry/name}} attribute to <code>"script"</code>.
 
-            NOTE: it is intentional that we record the frame's src attribute here, and not its current URL, as this is meant primarily to help identify frames, and allowing discovery of the current URL of a cross-origin iframe is a security problem.
-        3. Set |attribution|'s {{containerId}} attribute to the value of |iframe|'s [=Element/id=] content attribute, or <code>null</code> if the attribute is absent.
+            NOTE: future iterations of this API will add more values to the {{PerformanceEntry/name}} attribute of a {{TaskAttributionTiming}} object, but for now it can only be a single value.
 
-6. Create a new {{PerformanceLongTaskTiming}} object |newEntry| and set its attributes as follows:
+        2. Set |attribution|'s {{PerformanceEntry/entryType}} attribute to <code>"taskattribution"</code>.
+        3. Set |attribution|'s {{PerformanceEntry/startTime}} and {{PerformanceEntry/duration}} to 0.
+        4. If |culpritSettings| is not <code>null</code>, and |culpritSettings|'s <a>responsible browsing context</a> has a browsing context container that is an <{iframe}> element, then let |iframe| be that element, and perform the following steps:
+            1. Set |attribution|'s {{containerName}} attribute to the value of  |iframe|'s <{iframe/name}> content attribute, or <code>null</code> if the attribute is absent.
+            2. Set |attribution|'s {{containerSrc}} attribute to the value of |iframe|'s <{iframe/src}> content attribute, or <code>null</code> if the attribute is absent.
 
-    1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |name|.
-    2. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to <code>"longtask"</code>.
-    3. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |task|'s [=task/start time=].
-    4. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |task|'s [=task/end time=] minus [=task/start time=].
-    5. Set |newEntry|'s {{PerformanceLongTaskTiming/attribution}} attribute to a new frozen array containing the single value |attribution|.
+                NOTE: it is intentional that we record the frame's src attribute here, and not its current URL, as this is meant primarily to help identify frames, and allowing discovery of the current URL of a cross-origin iframe is a security problem.
+            3. Set |attribution|'s {{containerId}} attribute to the value of |iframe|'s [=Element/id=] content attribute, or <code>null</code> if the attribute is absent.
 
-        NOTE: future iterations of this API will add more values to the {{PerformanceLongTaskTiming/attribution}} attribute, but for now it only contains a single value.
+    6. Create a new {{PerformanceLongTaskTiming}} object |newEntry| and set its attributes as follows:
 
-7. <a>Queue the PerformanceEntry</a> |newEntry| on |destinationRealm|.
+        1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |name|.
+        2. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to <code>"longtask"</code>.
+        3. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |start time|.
+        4. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |end time| minus |start time|.
+        5. If |attribution| is not <code>null</code>, set |newEntry|'s {{PerformanceLongTaskTiming/attribution}} attribute to a new frozen array containing the single value |attribution|.
 
-    NOTE: the "queue a PerformanceEntry" algorithm will end up doing nothing if no observers are registered. Implementations likely will want to bail out from this algorithm earlier in that case, instead of assembling all the above information only to find out nobody is listening for it.
+            NOTE: future iterations of this API will add more values to the {{PerformanceLongTaskTiming/attribution}} attribute, but for now it only contains a single value.
+
+    6. <a>Queue the PerformanceEntry</a> |newEntry| on |destinationRealm|.
+
+        NOTE: the "queue a PerformanceEntry" algorithm will end up doing nothing if no observers are registered. Implementations likely will want to bail out from this algorithm earlier in that case, instead of assembling all the above information only to find out nobody is listening for it.
 
 Security & Privacy Considerations {#priv-sec}
 ===============================================


### PR DESCRIPTION
The purpose of this PR is to improve the definition of what a long task is. Before, a long task was equivalent to an event loop task that runs for a long time. With this change, a long task can come from an event loop task plus associated microtasks, a rendering update step, or browser work outside of the event loop.

Attribution for the new types of long tasks is skipped but the type of task is set in the |name| of the  PerformanceLongTaskTiming entry. The name is a bit overloaded because it already contains the frame attribution, so if needed a new |taskType| attribute can be added, but then it's unclear what |name| would be for the new long task types.

This PR also fixes some problems found along the way. Most notably, everything in the reporting algorithm following "For each destinationRealm in destinationRealms" must be a substep of this for loop because the last step consists of queueing the entry in the corresponding |destinationRealm|.