### PR TITLE
Refactor report long task

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -129,7 +129,7 @@ Long Task timing involves the following new interfaces:
     };
 </pre>
 
-The values of the attributes of a {{PerformanceLongTaskTiming}} are set in the processing model in [[#report-long-tasks]]. The following provides an informative summary of how they will be set.
+The values of the attributes of a {{PerformanceLongTaskTiming}} are set in the processing model in [[#report-long-task]]. The following provides an informative summary of how they will be set.
 
 The {{PerformanceEntry/name}} attribute's getter will return one of the following strings:
 
@@ -174,7 +174,7 @@ The <dfn attribute for=PerformanceLongTaskTiming>attribution</dfn> attribute's g
     };
 </pre>
 
-The values of the attributes of a {{TaskAttributionTiming}} are set in the processing model in [[#report-long-tasks]]. The following provides an informative summary of how they will be set.
+The values of the attributes of a {{TaskAttributionTiming}} are set in the processing model in [[#report-long-task]]. The following provides an informative summary of how they will be set.
 
 The {{PerformanceEntry/name}} attribute's getter will always return "<code>unknown</code>".
 
@@ -255,96 +255,84 @@ Processing model {#sec-processing-model}
 Note: A user agent implementing the Long Tasks API would need to include <code>"longtask"</code> in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts.
 This allows developers to detect support for long tasks.
 
-Report long tasks {#report-long-tasks}
+Report a long task {#report-long-task}
 --------------------------------------------------------
 
-<div algorithm="Report long tasks">
-    Given |start time|, |end time|, |top-level browsing contexts|, and optionally |task|, perform the following algorithm:
+<div algorithm="Report a long task">
+    When asked to <dfn export>report a long task</dfn> for a {{Document}} |document|, given |start time|, |end time|, and |task|, perform the following steps:
 
     1. If |end time| minus |start time| is less than the long tasks threshold of 50 ms, abort these steps.
 
-    1. Let |destinationRealms| be an empty set.
+    1. Let |destinationRealm| be |document|'s <a>relevant Realm</a>.
 
-    1. Determine the set of <a>JavaScript Realms</a> to which reports will be delivered:
+    1. Let |name| be the empty string. This will be used to report <a>minimal culprit attribution</a>, below.
+    1. Let |culpritSettings| be <code>null</code>.
+    1. Process |task|'s <a>script evaluation environment settings object set</a> to determine |name| and |culpritSettings| as follows:
 
-        For each <a>top-level browsing context</a> |topmostBC| in |top-level browsing contexts|:
+        1. If |task|'s <a>script evaluation environment settings object set</a> is empty: set |name| to "<code><a>unknown</a></code>" and |culpritSettings| to <code>null</code>.
+        1. If |task|'s <a>script evaluation environment settings object set</a>'s length is greater than one: set |name| to "<code><a>multiple-contexts</a></code>" and |culpritSettings| to <code>null</code>.
+        1. If |task|'s <a>script evaluation environment settings object set</a>'s length is one:
+            1. Set |culpritSettings| to the single item in |task|'s <a>script evaluation environment settings object set</a>.
+            1. Let |destinationSettings| be |destinationRealm|'s <a>relevant settings object</a>.
+            1. Let |destinationOrigin| be |destinationSettings|'s [=environment settings object/origin=].
+            1. Let |destinationBC| be |destinationSettings|'s <a>responsible browsing context</a>.
+            1. If |culpritSettings| is the same as |destinationSettings|, set |name| to "<code><a>self</a></code>".
+            1. If |culpritSettings|'s [=environment settings object/origin=] and |destinationOrigin| are <a>same origin</a>:
+                1. If |culpritSettings|'s <a>responsible browsing context</a> is an <a>ancestor</a> of |destinationBC|, set |name| to "<code><a>same-origin-ancestor</a></code>".
+                1. Otherwise, if |culpritSettings|'s <a>responsible browsing context</a> is a <a lt="list of the descendant browsing contexts">descendant</a> of |destinationBC|, set |name| to "<code><a>same-origin-descendant</a></code>".
+                1. Otherwise, set |name| to "<code><a>same-origin</a></code>".
+            1. Otherwise:
+                1. If |culpritSettings|'s <a>responsible browsing context</a> is an <a>ancestor</a> of |destinationBC|, set |name| to "<code><a>cross-origin-ancestor</a></code>" and set |culpritSettings| to <code>null</code>.
 
-        1. Add |topmostBC|'s Window's <a>relevant Realm</a> to |destinationRealms|.
-        1. Let |descendantBCs| be |topmostBC|'s <a>active document</a>'s <a>list of the descendant browsing contexts</a>.
-        1. For each |descendantBC| in |descendantBCs|, add |descendantBC|'s Window's <a>relevant Realm</a> to |destinationRealms|.
+                    NOTE: this is not reported because of security. Developers should look this up themselves.
 
-    1. For each |destinationRealm| in |destinationRealms|:
+                1. Otherwise, if |culpritSettings|'s <a>responsible browsing context</a> is a <a lt="list of the descendant browsing contexts">descendant</a> of |destinationBC|, set |name| to "<code><a>cross-origin-descendant</a></code>".
+                1. Otherwise, set |name| to "<code><a>cross-origin-unreachable</a></code>".
 
-        1. Let |name| be the empty string. This will be used to report <a>minimal culprit attribution</a>, below.
-        1. Let |culpritSettings| be <code>null</code>.
-        1. If the |task| argument was not provided, set |name| to "<code><a>unknown</a></code>".
-        1. Otherwise: process |task|'s <a>script evaluation environment settings object set</a> to determine |name| and |culpritSettings| as follows:
+    1. Let |attribution| be a new {{TaskAttributionTiming}} object with |destinationRealm| and set its attributes as follows:
+        1. Set |attribution|'s {{PerformanceEntry/name}} attribute to "<code><a>unknown</a></code>".
 
-            1. If |task|'s <a>script evaluation environment settings object set</a> is empty: set |name| to "<code><a>unknown</a></code>" and |culpritSettings| to <code>null</code>.
-            1. If |task|'s <a>script evaluation environment settings object set</a>'s length is greater than one: set |name| to "<code><a>multiple-contexts</a></code>" and |culpritSettings| to <code>null</code>.
-            1. If |task|'s <a>script evaluation environment settings object set</a>'s length is one:
-                1. Set |culpritSettings| to the single item in |task|'s <a>script evaluation environment settings object set</a>.
-                1. Let |destinationSettings| be |destinationRealm|'s <a>relevant settings object</a>.
-                1. Let |destinationOrigin| be |destinationSettings|'s [=environment settings object/origin=].
-                1. Let |destinationBC| be |destinationSettings|'s <a>responsible browsing context</a>.
-                1. If |culpritSettings| is the same as |destinationSettings|, set |name| to "<code><a>self</a></code>".
-                1. If |culpritSettings|'s [=environment settings object/origin=] and |destinationOrigin| are <a>same origin</a>:
-                    1. If |culpritSettings|'s <a>responsible browsing context</a> is an <a>ancestor</a> of |destinationBC|, set |name| to "<code><a>same-origin-ancestor</a></code>".
-                    1. Otherwise, if |culpritSettings|'s <a>responsible browsing context</a> is a <a lt="list of the descendant browsing contexts">descendant</a> of |destinationBC|, set |name| to "<code><a>same-origin-descendant</a></code>".
-                    1. Otherwise, set |name| to "<code><a>same-origin</a></code>".
-                1. Otherwise:
-                    1. If |culpritSettings|'s <a>responsible browsing context</a> is an <a>ancestor</a> of |destinationBC|, set |name| to "<code><a>cross-origin-ancestor</a></code>" and set |culpritSettings| to <code>null</code>.
+            NOTE: future iterations of this API will add more values to the {{PerformanceEntry/name}} attribute of a {{TaskAttributionTiming}} object, but for now it can only be a single value.
 
-                        NOTE: this is not reported because of security. Developers should look this up themselves.
+        1. Set |attribution|'s {{PerformanceEntry/entryType}} attribute to <code>"taskattribution"</code>.
+        1. Set |attribution|'s {{PerformanceEntry/startTime}} and {{PerformanceEntry/duration}} to 0.
+        1. Set |attribution|'s {{containerType}} attribute to <code>"window"</code>.
+        1. Set |attribution|'s {{containerName}} and {{containerSrc}} attributes to the empty string.
+        1. If |culpritSettings| is not <code>null</code>:
+            1. Let |container| be |culpritSettings|'s <a>responsible browsing context</a>'s <a>browsing context container</a>.
+            1. Assert: |container| is not <code>null</code>.
+            1. Set |attribution|'s {{containerId}} attribute to the value of |container|'s [=Element/ID=], or the empty string if the ID is unset.
+            1. If |container| is an <{iframe}> element:
+                1. Set |attribution|'s {{containerType}} attribute to "<code>iframe</code>".
+                1. Set |attribution|'s {{containerName}} attribute to the value of |container|'s <{iframe/name}> content attribute, or the empty string if the attribute is absent.
+                1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <{iframe/src}> content attribute, or the empty string if the attribute is absent.
 
-                    1. Otherwise, if |culpritSettings|'s <a>responsible browsing context</a> is a <a lt="list of the descendant browsing contexts">descendant</a> of |destinationBC|, set |name| to "<code><a>cross-origin-descendant</a></code>".
-                    1. Otherwise, set |name| to "<code><a>cross-origin-unreachable</a></code>".
+                NOTE: it is intentional that we record the frame's <{iframe/src}> attribute here, and not its current URL, as this is meant primarily to help identify frames, and allowing discovery of the current URL of a cross-origin iframe is a security problem.
 
-        1. If |task| was not provided, let |attribution| be <code>null</code>.
-        1. Otherwise, let |attribution| be a new {{TaskAttributionTiming}} object with |destinationRealm| and set its attributes as follows:
-            1. Set |attribution|'s {{PerformanceEntry/name}} attribute to "<code><a>unknown</a></code>".
+            1. If |container| is a <{frame}> element:
+                1. Set |attribution|'s {{containerType}} attribute to "<code>frame</code>".
+                1. Set |attribution|'s {{containerName}} attribute to the value of |container|'s <code>name</code> content attribute, or the empty string if the attribute is absent.
+                1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <code>src</code> content attribute, or the empty string if the attribute is absent.
+            1. If |container| is an <{object}> element:
+                1. Set |attribution|'s {{containerType}} attribute to "<code>object</code>".
+                1. Set |attribution|'s {{containerName}} attribute to the value of  |container|'s <{object/name}> content attribute, or the empty string if the attribute is absent.
+                1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <{object/data}> content attribute, or the empty string if the attribute is absent.
+            1. If |container| is an <{embed}> element:
+                1. Set |attribution|'s {{containerType}} attribute to "<code>embed</code>".
+                1. Set |attribution|'s {{containerName}} attribute to the empty string.
+                1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <{embed/src}> content attribute, or the empty string if the attribute is absent.
 
-                NOTE: future iterations of this API will add more values to the {{PerformanceEntry/name}} attribute of a {{TaskAttributionTiming}} object, but for now it can only be a single value.
+    1. Create a new {{PerformanceLongTaskTiming}} object |newEntry| with |destinationRealm| and set its attributes as follows:
 
-            1. Set |attribution|'s {{PerformanceEntry/entryType}} attribute to <code>"taskattribution"</code>.
-            1. Set |attribution|'s {{PerformanceEntry/startTime}} and {{PerformanceEntry/duration}} to 0.
-            1. Set |attribution|'s {{containerType}} attribute to <code>"window"</code>.
-            1. Set |attribution|'s {{containerName}} and {{containerSrc}} attributes to the empty string.
-            1. If |culpritSettings| is not <code>null</code>:
-                1. Let |container| be |culpritSettings|'s <a>responsible browsing context</a>'s <a>browsing context container</a>.
-                1. Assert: |container| is not <code>null</code>.
-                1. Set |attribution|'s {{containerId}} attribute to the value of |container|'s [=Element/ID=], or the empty string if the ID is unset.
-                1. If |container| is an <{iframe}> element:
-                    1. Set |attribution|'s {{containerType}} attribute to "<code>iframe</code>".
-                    1. Set |attribution|'s {{containerName}} attribute to the value of |container|'s <{iframe/name}> content attribute, or the empty string if the attribute is absent.
-                    1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <{iframe/src}> content attribute, or the empty string if the attribute is absent.
+        1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |name|.
+        1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to "<code>longtask</code>".
+        1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |start time|.
+        1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to |end time| minus |start time|.
+        1. If |attribution| is not <code>null</code>, set |newEntry|'s {{PerformanceLongTaskTiming/attribution}} attribute to a new frozen array containing the single value |attribution|.
 
-                    NOTE: it is intentional that we record the frame's <{iframe/src}> attribute here, and not its current URL, as this is meant primarily to help identify frames, and allowing discovery of the current URL of a cross-origin iframe is a security problem.
+            NOTE: future iterations of this API will add more values to the {{PerformanceLongTaskTiming/attribution}} attribute, but for now it only contains a single value.
 
-                1. If |container| is a <{frame}> element:
-                    1. Set |attribution|'s {{containerType}} attribute to "<code>frame</code>".
-                    1. Set |attribution|'s {{containerName}} attribute to the value of |container|'s <code>name</code> content attribute, or the empty string if the attribute is absent.
-                    1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <code>src</code> content attribute, or the empty string if the attribute is absent.
-                1. If |container| is an <{object}> element:
-                    1. Set |attribution|'s {{containerType}} attribute to "<code>object</code>".
-                    1. Set |attribution|'s {{containerName}} attribute to the value of  |container|'s <{object/name}> content attribute, or the empty string if the attribute is absent.
-                    1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <{object/data}> content attribute, or the empty string if the attribute is absent.
-                1. If |container| is an <{embed}> element:
-                    1. Set |attribution|'s {{containerType}} attribute to "<code>embed</code>".
-                    1. Set |attribution|'s {{containerName}} attribute to the empty string.
-                    1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <{embed/src}> content attribute, or the empty string if the attribute is absent.
-
-        1. Create a new {{PerformanceLongTaskTiming}} object |newEntry| with |destinationRealm| and set its attributes as follows:
-
-            1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |name|.
-            1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to "<code>longtask</code>".
-            1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |start time|.
-            1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to |end time| minus |start time|.
-            1. If |attribution| is not <code>null</code>, set |newEntry|'s {{PerformanceLongTaskTiming/attribution}} attribute to a new frozen array containing the single value |attribution|.
-
-                NOTE: future iterations of this API will add more values to the {{PerformanceLongTaskTiming/attribution}} attribute, but for now it only contains a single value.
-
-        1. <a>Queue the PerformanceEntry</a> |newEntry|.
+    1. <a>Queue the PerformanceEntry</a> |newEntry|.
 </div>
 
 Security & privacy considerations {#priv-sec}

--- a/index.bs
+++ b/index.bs
@@ -265,52 +265,52 @@ Report long tasks {#report-long-tasks}
 
     1. Let |destinationRealms| be an empty set.
 
-    1. Determine the set of <a>JavaScript Realms</a> to which reports will be delivered:
+    1. Determine the set of [=JavaScript Realms=] to which reports will be delivered:
 
-        For each <a>top-level browsing context</a> |topmostBC| in |top-level browsing contexts|:
+        For each [=top-level browsing context=] |topmostBC| in |top-level browsing contexts|:
 
-        1. Add |topmostBC|'s <a>active document</a>'s <a>relevant Realm</a> to |destinationRealms|.
-        1. Let |descendantBCs| be |topmostBC|'s <a>active document</a>'s <a>list of the descendant browsing contexts</a>.
-        1. For each |descendantBC| in |descendantBCs|, add |descendantBC|'s <a>active document</a>'s <a>relevant Realm</a> to |destinationRealms|.
+        1. Add |topmostBC|'s [=active document=]'s [=relevant Realm=] to |destinationRealms|.
+        1. Let |descendantBCs| be |topmostBC|'s [=active document=]'s [=list of the descendant browsing contexts=].
+        1. For each |descendantBC| in |descendantBCs|, add |descendantBC|'s [=active document=]'s [=relevant Realm=] to |destinationRealms|.
     
-    1. A user agent may remove some <a>JavaScript Realms</a> from |destinationRealms|.
+    1. A user agent may remove some [=JavaScript Realms=] from |destinationRealms|.
 
-    Note: this removal could be used to avoid reporting long tasks for <a>JavaScript Realms</a> that the user agent handles in a separate process. However, this concept is not specified precisely.
+    Note: this removal could be used to avoid reporting long tasks for [=JavaScript Realms=] that the user agent handles in a separate process. However, this concept is not specified precisely.
 
     Issue(75): there is some ongoing discussion regarding the scope of which {{Document|Documents}} gain visibility over which long tasks, so this logic could change in the future.
 
     1. For each |destinationRealm| in |destinationRealms|:
 
-        1. Let |name| be the empty string. This will be used to report <a>minimal culprit attribution</a>, below.
+        1. Let |name| be the empty string. This will be used to report [=minimal culprit attribution=], below.
         1. Let |culpritSettings| be <code>null</code>.
-        1. Process |task|'s <a>script evaluation environment settings object set</a> to determine |name| and |culpritSettings| as follows:
+        1. Process |task|'s [=script evaluation environment settings object set=] to determine |name| and |culpritSettings| as follows:
 
-            1. If |task|'s <a>script evaluation environment settings object set</a> is empty: set |name| to "<code><a>unknown</a></code>" and |culpritSettings| to <code>null</code>.
-            1. Otherwise, if |task|'s <a>script evaluation environment settings object set</a>'s length is greater than one: set |name| to "<code><a>multiple-contexts</a></code>" and |culpritSettings| to <code>null</code>.
-            1. Otherwise, i.e. if |task|'s <a>script evaluation environment settings object set</a>'s length is one:
-                1. Set |culpritSettings| to the single item in |task|'s <a>script evaluation environment settings object set</a>.
-                1. Let |destinationSettings| be |destinationRealm|'s <a for=Realm>settings object</a>.
+            1. If |task|'s [=script evaluation environment settings object set=] is empty: set |name| to "<code>[=unknown=]</code>" and |culpritSettings| to <code>null</code>.
+            1. Otherwise, if |task|'s [=script evaluation environment settings object set=]'s length is greater than one: set |name| to "<code>[=multiple-contexts=]</code>" and |culpritSettings| to <code>null</code>.
+            1. Otherwise, i.e. if |task|'s [=script evaluation environment settings object set=]'s length is one:
+                1. Set |culpritSettings| to the single item in |task|'s [=script evaluation environment settings object set=].
+                1. Let |destinationSettings| be |destinationRealm|'s [=Realm/settings object=].
                 1. Let |destinationOrigin| be |destinationSettings|'s [=environment settings object/origin=].
-                1. Let |destinationBC| be |destinationSettings|'s <a for="environment settings object">global object</a>'s <a for=Window>browsing context</a>.
-                1. Let |culpritBC| be |culpritSettings|'s <a for="environment settings object">global object</a>'s <a for=Window>browsing context</a>.
+                1. Let |destinationBC| be |destinationSettings|'s [=environment settings object/global object=]'s [=Window/browsing context=].
+                1. Let |culpritBC| be |culpritSettings|'s [=environment settings object/global object=]'s [=Window/browsing context=].
                 1. Assert: |culpritBC| is not <code>null</code>.
-                1. If |culpritSettings| is the same as |destinationSettings|, set |name| to "<code><a>self</a></code>".
-                1. Otherwise, if |culpritSettings|'s [=environment settings object/origin=] and |destinationOrigin| are <a>same origin</a>:
-                    1. If |destinationBC| is <code>null</code>, set |name| to "<code><a>same-origin</a></code>".
-                    1. Otherwise, if |culpritBC| is an <a>ancestor</a> of |destinationBC|, set |name| to "<code><a>same-origin-ancestor</a></code>".
-                    1. Otherwise, if |destinationBC| is an <a>ancestor</a> of |culpritBC|, set |name| to "<code><a>same-origin-descendant</a></code>".
-                    1. Otherwise, set |name| to "<code><a>same-origin</a></code>".
+                1. If |culpritSettings| is the same as |destinationSettings|, set |name| to "<code>[=self=]</code>".
+                1. Otherwise, if |culpritSettings|'s [=environment settings object/origin=] and |destinationOrigin| are [=same origin=]:
+                    1. If |destinationBC| is <code>null</code>, set |name| to "<code>[=same-origin=]</code>".
+                    1. Otherwise, if |culpritBC| is an [=ancestor=] of |destinationBC|, set |name| to "<code>[=same-origin-ancestor=]</code>".
+                    1. Otherwise, if |destinationBC| is an [=ancestor=] of |culpritBC|, set |name| to "<code>[=same-origin-descendant=]</code>".
+                    1. Otherwise, set |name| to "<code>[=same-origin=]</code>".
                 1. Otherwise:
-                    1. If |destinationBC| is <code>null</code>, set |name| to "<code><a>cross-origin-unreachable</a></code>".
-                    1. Otherwise, if |culpritBC| is an <a>ancestor</a> of |destinationBC|, set |name| to "<code><a>cross-origin-ancestor</a></code>" and set |culpritSettings| to <code>null</code>.
+                    1. If |destinationBC| is <code>null</code>, set |name| to "<code>[=cross-origin-unreachable=]</code>".
+                    1. Otherwise, if |culpritBC| is an [=ancestor=] of |destinationBC|, set |name| to "<code>[=cross-origin-ancestor=]</code>" and set |culpritSettings| to <code>null</code>.
 
                         NOTE: this is not reported because of security. Developers should look this up themselves.
 
-                    1. Otherwise, if |destinationBC| is an <a>ancestor</a> of |culpritBC|, set |name| to "<code><a>cross-origin-descendant</a></code>".
-                    1. Otherwise, set |name| to "<code><a>cross-origin-unreachable</a></code>".
+                    1. Otherwise, if |destinationBC| is an [=ancestor=] of |culpritBC|, set |name| to "<code>[=cross-origin-descendant=]</code>".
+                    1. Otherwise, set |name| to "<code>[=cross-origin-unreachable=]</code>".
 
         1. Let |attribution| be a new {{TaskAttributionTiming}} object with |destinationRealm| and set its attributes as follows:
-            1. Set |attribution|'s {{PerformanceEntry/name}} attribute to "<code><a>unknown</a></code>".
+            1. Set |attribution|'s {{PerformanceEntry/name}} attribute to "<code>[=unknown=]</code>".
 
                 NOTE: future iterations of this API will add more values to the {{PerformanceEntry/name}} attribute of a {{TaskAttributionTiming}} object, but for now it can only be a single value.
 
@@ -319,9 +319,9 @@ Report long tasks {#report-long-tasks}
             1. Set |attribution|'s {{containerType}} attribute to <code>"window"</code>.
             1. Set |attribution|'s {{containerName}} and {{containerSrc}} attributes to the empty string.
             1. If |culpritSettings| is not <code>null</code>:
-                1. Let |culpritBC| be |culpritSettings|'s <a for="environment settings object">global object</a>'s <a for=Window>browsing context</a>.
+                1. Let |culpritBC| be |culpritSettings|'s [=environment settings object/global object=]'s [=Window/browsing context=].
                 1. Assert: |culpritBC| is not <code>null</code>.
-                1. Let |container| be |culpritBC|'s <a>browsing context container</a>.
+                1. Let |container| be |culpritBC|'s [=browsing context container=].
                 1. Assert: |container| is not <code>null</code>.
                 1. Set |attribution|'s {{containerId}} attribute to the value of |container|'s [=Element/ID=], or the empty string if the ID is unset.
                 1. If |container| is an <{iframe}> element:
@@ -354,7 +354,7 @@ Report long tasks {#report-long-tasks}
 
                 NOTE: future iterations of this API will add more values to the {{PerformanceLongTaskTiming/attribution}} attribute, but for now it only contains a single value.
 
-        1. <a>Queue the PerformanceEntry</a> |newEntry|.
+        1. [=Queue the PerformanceEntry=] |newEntry|.
 </div>
 
 Security & privacy considerations {#priv-sec}

--- a/index.bs
+++ b/index.bs
@@ -129,12 +129,12 @@ Long Task timing involves the following new interfaces:
     };
 </pre>
 
-The values of the attributes of a {{PerformanceLongTaskTiming}} are set in the processing model in [[#report-long-task]]. The following provides an informative summary of how they will be set.
+The values of the attributes of a {{PerformanceLongTaskTiming}} are set in the processing model in [[#report-long-tasks]]. The following provides an informative summary of how they will be set.
 
 The {{PerformanceEntry/name}} attribute's getter will return one of the following strings:
 
 : "<code><dfn>unknown</dfn></code>"
-:: The long task originated from an <a>update the rendering</a> step within the <a>event loop processing model</a> or work the user agent performed outside of the <a>event loop</a>.
+:: The long task originated from work that the user agent performed outside of the <a>event loop</a>.
 : "<code><dfn>self</dfn></code>"
 :: The long task originated from an event loop <a>task</a> within this <a>browsing context</a>.
 : "<code><dfn>same-origin-ancestor</dfn></code>"
@@ -174,7 +174,7 @@ The <dfn attribute for=PerformanceLongTaskTiming>attribution</dfn> attribute's g
     };
 </pre>
 
-The values of the attributes of a {{TaskAttributionTiming}} are set in the processing model in [[#report-long-task]]. The following provides an informative summary of how they will be set.
+The values of the attributes of a {{TaskAttributionTiming}} are set in the processing model in [[#report-long-tasks]]. The following provides an informative summary of how they will be set.
 
 The {{PerformanceEntry/name}} attribute's getter will always return "<code>unknown</code>".
 
@@ -255,84 +255,106 @@ Processing model {#sec-processing-model}
 Note: A user agent implementing the Long Tasks API would need to include <code>"longtask"</code> in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts.
 This allows developers to detect support for long tasks.
 
-Report a long task {#report-long-task}
+Report long tasks {#report-long-tasks}
 --------------------------------------------------------
 
-<div algorithm="Report a long task">
-    When asked to <dfn export>report a long task</dfn> for a {{Document}} |document|, given |start time|, |end time|, and |task|, perform the following steps:
+<div algorithm="Report long tasks">
+    Given |start time|, |end time|, |top-level browsing contexts|, and |task|, perform the following algorithm:
 
     1. If |end time| minus |start time| is less than the long tasks threshold of 50 ms, abort these steps.
 
-    1. Let |destinationRealm| be |document|'s <a>relevant Realm</a>.
+    1. Let |destinationRealms| be an empty set.
 
-    1. Let |name| be the empty string. This will be used to report <a>minimal culprit attribution</a>, below.
-    1. Let |culpritSettings| be <code>null</code>.
-    1. Process |task|'s <a>script evaluation environment settings object set</a> to determine |name| and |culpritSettings| as follows:
+    1. Determine the set of <a>JavaScript Realms</a> to which reports will be delivered:
 
-        1. If |task|'s <a>script evaluation environment settings object set</a> is empty: set |name| to "<code><a>unknown</a></code>" and |culpritSettings| to <code>null</code>.
-        1. If |task|'s <a>script evaluation environment settings object set</a>'s length is greater than one: set |name| to "<code><a>multiple-contexts</a></code>" and |culpritSettings| to <code>null</code>.
-        1. If |task|'s <a>script evaluation environment settings object set</a>'s length is one:
-            1. Set |culpritSettings| to the single item in |task|'s <a>script evaluation environment settings object set</a>.
-            1. Let |destinationSettings| be |destinationRealm|'s <a>relevant settings object</a>.
-            1. Let |destinationOrigin| be |destinationSettings|'s [=environment settings object/origin=].
-            1. Let |destinationBC| be |destinationSettings|'s <a>responsible browsing context</a>.
-            1. If |culpritSettings| is the same as |destinationSettings|, set |name| to "<code><a>self</a></code>".
-            1. If |culpritSettings|'s [=environment settings object/origin=] and |destinationOrigin| are <a>same origin</a>:
-                1. If |culpritSettings|'s <a>responsible browsing context</a> is an <a>ancestor</a> of |destinationBC|, set |name| to "<code><a>same-origin-ancestor</a></code>".
-                1. Otherwise, if |culpritSettings|'s <a>responsible browsing context</a> is a <a lt="list of the descendant browsing contexts">descendant</a> of |destinationBC|, set |name| to "<code><a>same-origin-descendant</a></code>".
-                1. Otherwise, set |name| to "<code><a>same-origin</a></code>".
-            1. Otherwise:
-                1. If |culpritSettings|'s <a>responsible browsing context</a> is an <a>ancestor</a> of |destinationBC|, set |name| to "<code><a>cross-origin-ancestor</a></code>" and set |culpritSettings| to <code>null</code>.
+        For each <a>top-level browsing context</a> |topmostBC| in |top-level browsing contexts|:
 
-                    NOTE: this is not reported because of security. Developers should look this up themselves.
+        1. Add |topmostBC|'s <a>active document</a>'s <a>relevant Realm</a> to |destinationRealms|.
+        1. Let |descendantBCs| be |topmostBC|'s <a>active document</a>'s <a>list of the descendant browsing contexts</a>.
+        1. For each |descendantBC| in |descendantBCs|, add |descendantBC|'s <a>active document</a>'s <a>relevant Realm</a> to |destinationRealms|.
+    
+    1. A user agent may remove some <a>JavaScript Realms</a> from |destinationRealms|.
 
-                1. Otherwise, if |culpritSettings|'s <a>responsible browsing context</a> is a <a lt="list of the descendant browsing contexts">descendant</a> of |destinationBC|, set |name| to "<code><a>cross-origin-descendant</a></code>".
-                1. Otherwise, set |name| to "<code><a>cross-origin-unreachable</a></code>".
+    Note: this removal could be used to avoid reporting long tasks for <a>JavaScript Realms</a> that the user agent handles in a separate process. However, this concept is not specified precisely.
 
-    1. Let |attribution| be a new {{TaskAttributionTiming}} object with |destinationRealm| and set its attributes as follows:
-        1. Set |attribution|'s {{PerformanceEntry/name}} attribute to "<code><a>unknown</a></code>".
+    Issue(75): there is some ongoing discussion regarding the scope of which {{Document|Documents}} gain visibility over which long tasks, so this logic could change in the future.
 
-            NOTE: future iterations of this API will add more values to the {{PerformanceEntry/name}} attribute of a {{TaskAttributionTiming}} object, but for now it can only be a single value.
+    1. For each |destinationRealm| in |destinationRealms|:
 
-        1. Set |attribution|'s {{PerformanceEntry/entryType}} attribute to <code>"taskattribution"</code>.
-        1. Set |attribution|'s {{PerformanceEntry/startTime}} and {{PerformanceEntry/duration}} to 0.
-        1. Set |attribution|'s {{containerType}} attribute to <code>"window"</code>.
-        1. Set |attribution|'s {{containerName}} and {{containerSrc}} attributes to the empty string.
-        1. If |culpritSettings| is not <code>null</code>:
-            1. Let |container| be |culpritSettings|'s <a>responsible browsing context</a>'s <a>browsing context container</a>.
-            1. Assert: |container| is not <code>null</code>.
-            1. Set |attribution|'s {{containerId}} attribute to the value of |container|'s [=Element/ID=], or the empty string if the ID is unset.
-            1. If |container| is an <{iframe}> element:
-                1. Set |attribution|'s {{containerType}} attribute to "<code>iframe</code>".
-                1. Set |attribution|'s {{containerName}} attribute to the value of |container|'s <{iframe/name}> content attribute, or the empty string if the attribute is absent.
-                1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <{iframe/src}> content attribute, or the empty string if the attribute is absent.
+        1. Let |name| be the empty string. This will be used to report <a>minimal culprit attribution</a>, below.
+        1. Let |culpritSettings| be <code>null</code>.
+        1. Process |task|'s <a>script evaluation environment settings object set</a> to determine |name| and |culpritSettings| as follows:
 
-                NOTE: it is intentional that we record the frame's <{iframe/src}> attribute here, and not its current URL, as this is meant primarily to help identify frames, and allowing discovery of the current URL of a cross-origin iframe is a security problem.
+            1. If |task|'s <a>script evaluation environment settings object set</a> is empty: set |name| to "<code><a>unknown</a></code>" and |culpritSettings| to <code>null</code>.
+            1. Otherwise, if |task|'s <a>script evaluation environment settings object set</a>'s length is greater than one: set |name| to "<code><a>multiple-contexts</a></code>" and |culpritSettings| to <code>null</code>.
+            1. Otherwise, i.e. if |task|'s <a>script evaluation environment settings object set</a>'s length is one:
+                1. Set |culpritSettings| to the single item in |task|'s <a>script evaluation environment settings object set</a>.
+                1. Let |destinationSettings| be |destinationRealm|'s <a for=Realm>settings object</a>.
+                1. Let |destinationOrigin| be |destinationSettings|'s [=environment settings object/origin=].
+                1. Let |destinationBC| be |destinationSettings|'s <a for="environment settings object">global object</a>'s <a for=Window>browsing context</a>.
+                1. Let |culpritBC| be |culpritSettings|'s <a for="environment settings object">global object</a>'s <a for=Window>browsing context</a>.
+                1. Assert: |culpritBC| is not <code>null</code>.
+                1. If |culpritSettings| is the same as |destinationSettings|, set |name| to "<code><a>self</a></code>".
+                1. Otherwise, if |culpritSettings|'s [=environment settings object/origin=] and |destinationOrigin| are <a>same origin</a>:
+                    1. If |destinationBC| is <code>null</code>, set |name| to "<code><a>same-origin</a></code>".
+                    1. Otherwise, if |culpritBC| is an <a>ancestor</a> of |destinationBC|, set |name| to "<code><a>same-origin-ancestor</a></code>".
+                    1. Otherwise, if |destinationBC| is an <a>ancestor</a> of |culpritBC|, set |name| to "<code><a>same-origin-descendant</a></code>".
+                    1. Otherwise, set |name| to "<code><a>same-origin</a></code>".
+                1. Otherwise:
+                    1. If |destinationBC| is <code>null</code>, set |name| to "<code><a>cross-origin-unreachable</a></code>".
+                    1. Otherwise, if |culpritBC| is an <a>ancestor</a> of |destinationBC|, set |name| to "<code><a>cross-origin-ancestor</a></code>" and set |culpritSettings| to <code>null</code>.
 
-            1. If |container| is a <{frame}> element:
-                1. Set |attribution|'s {{containerType}} attribute to "<code>frame</code>".
-                1. Set |attribution|'s {{containerName}} attribute to the value of |container|'s <code>name</code> content attribute, or the empty string if the attribute is absent.
-                1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <code>src</code> content attribute, or the empty string if the attribute is absent.
-            1. If |container| is an <{object}> element:
-                1. Set |attribution|'s {{containerType}} attribute to "<code>object</code>".
-                1. Set |attribution|'s {{containerName}} attribute to the value of  |container|'s <{object/name}> content attribute, or the empty string if the attribute is absent.
-                1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <{object/data}> content attribute, or the empty string if the attribute is absent.
-            1. If |container| is an <{embed}> element:
-                1. Set |attribution|'s {{containerType}} attribute to "<code>embed</code>".
-                1. Set |attribution|'s {{containerName}} attribute to the empty string.
-                1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <{embed/src}> content attribute, or the empty string if the attribute is absent.
+                        NOTE: this is not reported because of security. Developers should look this up themselves.
 
-    1. Create a new {{PerformanceLongTaskTiming}} object |newEntry| with |destinationRealm| and set its attributes as follows:
+                    1. Otherwise, if |destinationBC| is an <a>ancestor</a> of |culpritBC|, set |name| to "<code><a>cross-origin-descendant</a></code>".
+                    1. Otherwise, set |name| to "<code><a>cross-origin-unreachable</a></code>".
 
-        1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |name|.
-        1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to "<code>longtask</code>".
-        1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |start time|.
-        1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to |end time| minus |start time|.
-        1. If |attribution| is not <code>null</code>, set |newEntry|'s {{PerformanceLongTaskTiming/attribution}} attribute to a new frozen array containing the single value |attribution|.
+        1. Let |attribution| be a new {{TaskAttributionTiming}} object with |destinationRealm| and set its attributes as follows:
+            1. Set |attribution|'s {{PerformanceEntry/name}} attribute to "<code><a>unknown</a></code>".
 
-            NOTE: future iterations of this API will add more values to the {{PerformanceLongTaskTiming/attribution}} attribute, but for now it only contains a single value.
+                NOTE: future iterations of this API will add more values to the {{PerformanceEntry/name}} attribute of a {{TaskAttributionTiming}} object, but for now it can only be a single value.
 
-    1. <a>Queue the PerformanceEntry</a> |newEntry|.
+            1. Set |attribution|'s {{PerformanceEntry/entryType}} attribute to <code>"taskattribution"</code>.
+            1. Set |attribution|'s {{PerformanceEntry/startTime}} and {{PerformanceEntry/duration}} to 0.
+            1. Set |attribution|'s {{containerType}} attribute to <code>"window"</code>.
+            1. Set |attribution|'s {{containerName}} and {{containerSrc}} attributes to the empty string.
+            1. If |culpritSettings| is not <code>null</code>:
+                1. Let |culpritBC| be |culpritSettings|'s <a for="environment settings object">global object</a>'s <a for=Window>browsing context</a>.
+                1. Assert: |culpritBC| is not <code>null</code>.
+                1. Let |container| be |culpritBC|'s <a>browsing context container</a>.
+                1. Assert: |container| is not <code>null</code>.
+                1. Set |attribution|'s {{containerId}} attribute to the value of |container|'s [=Element/ID=], or the empty string if the ID is unset.
+                1. If |container| is an <{iframe}> element:
+                    1. Set |attribution|'s {{containerType}} attribute to "<code>iframe</code>".
+                    1. Set |attribution|'s {{containerName}} attribute to the value of |container|'s <{iframe/name}> content attribute, or the empty string if the attribute is absent.
+                    1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <{iframe/src}> content attribute, or the empty string if the attribute is absent.
+
+                    NOTE: it is intentional that we record the frame's <{iframe/src}> attribute here, and not its current URL, as this is meant primarily to help identify frames, and allowing discovery of the current URL of a cross-origin iframe is a security problem.
+
+                1. If |container| is a <{frame}> element:
+                    1. Set |attribution|'s {{containerType}} attribute to "<code>frame</code>".
+                    1. Set |attribution|'s {{containerName}} attribute to the value of |container|'s <code>name</code> content attribute, or the empty string if the attribute is absent.
+                    1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <code>src</code> content attribute, or the empty string if the attribute is absent.
+                1. If |container| is an <{object}> element:
+                    1. Set |attribution|'s {{containerType}} attribute to "<code>object</code>".
+                    1. Set |attribution|'s {{containerName}} attribute to the value of  |container|'s <{object/name}> content attribute, or the empty string if the attribute is absent.
+                    1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <{object/data}> content attribute, or the empty string if the attribute is absent.
+                1. If |container| is an <{embed}> element:
+                    1. Set |attribution|'s {{containerType}} attribute to "<code>embed</code>".
+                    1. Set |attribution|'s {{containerName}} attribute to the empty string.
+                    1. Set |attribution|'s {{containerSrc}} attribute to the value of |container|'s <{embed/src}> content attribute, or the empty string if the attribute is absent.
+
+        1. Create a new {{PerformanceLongTaskTiming}} object |newEntry| with |destinationRealm| and set its attributes as follows:
+
+            1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |name|.
+            1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to "<code>longtask</code>".
+            1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |start time|.
+            1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to |end time| minus |start time|.
+            1. If |attribution| is not <code>null</code>, set |newEntry|'s {{PerformanceLongTaskTiming/attribution}} attribute to a new frozen array containing the single value |attribution|.
+
+                NOTE: future iterations of this API will add more values to the {{PerformanceLongTaskTiming/attribution}} attribute, but for now it only contains a single value.
+
+        1. <a>Queue the PerformanceEntry</a> |newEntry|.
 </div>
 
 Security & privacy considerations {#priv-sec}


### PR DESCRIPTION
This PR changes the algorithm that reports long tasks as follows:
* Makes the `task` parameter mandatory as we do not intend to report long tasks from rendering.
* Allows the user agent to remove browsing contexts as that is what the implementer currently does. Points the reader to an issue which may change the behavior.
* Various editorial fixes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/longtasks/pull/84.html" title="Last updated on Apr 17, 2020, 5:40 PM UTC (e90cd85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/longtasks/84/1bc389a...e90cd85.html" title="Last updated on Apr 17, 2020, 5:40 PM UTC (e90cd85)">Diff</a>