### PR TITLE
Coarsen timestamps when reporting

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -275,7 +275,8 @@ Report long tasks {#report-long-tasks}
 
         1. Add |topmostBC|'s [=active document=]'s [=relevant Realm=] to |destinationRealms|.
         1. Let |descendantBCs| be |topmostBC|'s [=active document=]'s [=list of the descendant browsing contexts=].
-        1. For each |descendantBC| in |descendantBCs|, add |descendantBC|'s [=active document=]'s [=relevant Realm=] to |destinationRealms|.
+        1. Let |document| be |descendantBC|'s [=active document=].
+        1. For each |descendantBC| in |descendantBCs|, add (|document|'s [=relevant Realm=], |document|'s [=relevant settings object=]'s [=environment settings object/cross origin isolated capability=]) to |destinationRealms|.
 
     1. A user agent may remove some [=JavaScript Realms=] from |destinationRealms|.
 
@@ -283,7 +284,7 @@ Report long tasks {#report-long-tasks}
 
     Issue(75): there is some ongoing discussion regarding the scope of which {{Document|Documents}} gain visibility over which long tasks, so this logic could change in the future.
 
-    1. For each |destinationRealm| in |destinationRealms|:
+    1. For each (|destinationRealm|, |crossOriginIsolatedCapability|) in |destinationRealms|:
 
         1. Let |name| be the empty string. This will be used to report [=minimal culprit attribution=], below.
         1. Let |culpritSettings| be <code>null</code>.
@@ -352,8 +353,8 @@ Report long tasks {#report-long-tasks}
 
             1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to |name|.
             1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to "<code>longtask</code>".
-            1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to |start time|.
-            1. Let |dur| be |end time| minus |start time|.
+            1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to the result of [=coarsen time|coarsening=] |start time| given |crossOriginIsolatedCapability|.
+            1. Let |dur| be the result of [=coarsen time|coarsening=] |end time| given |crossOriginIsolatedCapability|, minus |newEntry|'s {{PerformanceEntry/startTime}}.
             1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to the integer part of |dur|.
             1. If |attribution| is not <code>null</code>, set |newEntry|'s {{PerformanceLongTaskTiming/attribution}} attribute to a new frozen array containing the single value |attribution|.
 

--- a/index.bs
+++ b/index.bs
@@ -276,7 +276,7 @@ Report long tasks {#report-long-tasks}
         1. Add |topmostBC|'s [=active document=]'s [=relevant Realm=] to |destinationRealms|.
         1. Let |descendantBCs| be |topmostBC|'s [=active document=]'s [=list of the descendant browsing contexts=].
         1. Let |document| be |descendantBC|'s [=active document=].
-        1. For each |descendantBC| in |descendantBCs|, add (|document|'s [=relevant Realm=], |document|'s [=relevant settings object=]'s [=environment settings object/cross origin isolated capability=]) to |destinationRealms|.
+        1. For each |descendantBC| in |descendantBCs|, add (|document|'s [=relevant Realm=], |document|'s [=relevant settings object=]'s [=environment settings object/cross-origin isolated capability=]) to |destinationRealms|.
 
     1. A user agent may remove some [=JavaScript Realms=] from |destinationRealms|.
 


### PR DESCRIPTION
The start/end time passed from HTML are unsafe, and coarsened based on the BC

Closes w3c/longtasks#98


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/longtasks/pull/99.html" title="Last updated on Apr 14, 2022, 8:30 AM UTC (37e1726)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/longtasks/99/9f48be0...37e1726.html" title="Last updated on Apr 14, 2022, 8:30 AM UTC (37e1726)">Diff</a>