### PR TITLE
Long Animation Frame (LoAF) explainer

### DIFF
--- a/loaf-explainer.md
+++ b/loaf-explainer.md
@@ -244,6 +244,21 @@ while (true) {
 }
 ```
 
+### Security & Privacy Considerations
+
+At the most part, LoAF only exposes information across same-origin windows. Information about
+scripts within a window is already observable, e.g. using resource timing or a service worker.
+
+However, LoAF might expose rendering information for a particular document tree that may be
+cross-origin (same-agent/site). The details about rendering the frame, such as
+`styleAndLayoutStartTime`, are proposed to be visible to all the same-agent windows that are
+rendered serially. That's because this information is already observable, by using
+`requestAnimationFrame` and `ResizeObserver` and measuring the delay between them. The premise is
+that global "update the rendering" timing information is already observable across same-agent
+windows, so exposing it directly does not leak new cross-origin information. However, the idea
+exposing less information to cross-origin same-agent subframes (as in, expose ) is open for
+discussion.
+
 ### Notes, complexity, doubts, future ideas, TODOs
 
 1. One complexity inherited from long tasks is the fact that the event loop is shared across

--- a/loaf-explainer.md
+++ b/loaf-explainer.md
@@ -1,0 +1,213 @@
+# Long Animation Frames (LoAF)
+Long Tasks Revamped
+
+## History
+
+Long tasks have long been a way to diagnose and track lack of responsiveness or "jankiness", which eventually affects core web vital metrics like [INP](https://web.dev/inp/). Developers have been using them with varying degrees of success, and now we can learn from the
+experience and see what can be improved going forward.
+
+## Where long tasks fall short
+
+Long tasks rely on the underlying notion of a [task](https://html.spec.whatwg.org/#concept-task). This is a somewhat well-specified term, but we found that it has
+a few shortcomings.
+
+1. A task does not include the [update the rendering](https://html.spec.whatwg.org/#update-the-rendering) phase. That phase includes `requestAnimationFrame` callbacks,
+resize observers, scroll observers and so on. This means that a lot of the busy time
+that blocks feedback or animation is not actually counted as part of the "long task",
+and developers can game their long task timing by moving long operations into a
+`requestAnimationFrame` callback.
+
+1. A task in implementations is used for internal scheduling, and not just as an
+implementation of the spec concept of task. This means that changes to implementation detail related to scheduling affects the measurement of long tasks, sometimes in
+unexpected, incompatible or arbitrary ways. A big implementation change in chrome silently changed the meaning of long tasks, when we started updating the rendering as part of a new task.
+
+1. Some operations that should be tasks are not specified or implemented to use tasks.
+For example, it is not specified how UI events are integrated into the event loop and
+the use of tasks there is implementation-specific.
+
+1. A task may contain multiple callbacks, e.g. dispatch several events. This makes
+it sometimes confusing to decipher what was the root cause of a long task.
+
+All of the above are part of the same issue - a task is an incomplete and inaccurate cadence to measure main-thread blocking. It's either too granular (as several tasks together may be the cause of blocking) or too coarse (as it may batch together several event handlers and so on).
+
+## Introducing LoAF
+
+LoAF (long animation frame) is a new proposed cadence (period of time) and performance entry type, meant to be a progression of the long task concept.
+
+It's the time measured between when the main thread started doing any work (see `startTime` [here](https://html.spec.whatwg.org/#event-loop-processing-model)), until it is [ready to paint](https://html.spec.whatwg.org/#event-loop-processing-model:mark-paint-timing). It may include several tasks (e.g. a few short ones and then a long one). Because it ends at the paint-mark time, it
+includes all the rendering obsevers (requestAnimationFrame, ResizeObserver etc.) and
+may or may not include presentation time (as that is somewhat implementation specific).
+
+In addition to making the cadence fit better with what it measures, the entry would include extra information to help understand what made it long, and what kind of consequences it had:
+
+- Time spent in forced layout/style calculations - e.g. calling `getBoundingClientRect`, doing more processing, and then rendering (also known as "layout thrashing" or "forced reflow").
+- How many rendering opportuinities were missed - counting points in time where the browser was ready to receive a new paint but the main thread was busy with this LoAF.
+- Is the frame blocking animation/input-feedback *in practice*. Note that a frame that blocks actual UI events would also be accessible via [event timing](https://w3c.github.io/event-timing/).
+- User scripts processed during the time of the frame, be it callbacks, event handlers, promise resolvers, or script block parsing and evaluation, and information about those scripts (source, how long they've been delayed for).
+
+## How a LoAF entry might look like
+```js
+const someLongAnimationFrameEntry = {
+    entryType: "long-animation-frame",
+
+    // https://html.spec.whatwg.org/#event-loop-processing-model, see |taskStartTime|
+    startTime: taskStartTime,
+
+    // https://html.spec.whatwg.org/#event-loop-processing-model (17)
+    // This is a well-specified and interoperable time, but doesn't include presentation time
+    duration: markPaintTimingTime - taskStartTime,
+
+    // Time spent in style/layout due to JS ("layout thrashing"), e.g. getBoundingClientRect() or
+    // getComputedStyle(). This is only taken into account if there is also a layout/style update
+    // in the final rendering phase.
+    totalForcedStyleAndLayoutDuration,
+
+    // The number of times there was a render opportunity but the main thread was busy
+    // processing this frame
+    discardedRenderOpportunities,
+
+    // Whether this long frame was blocking input/animation in practice
+    blocking: 'ui-event' | 'animation' | 'none',
+
+    // The implementation-specific time when the frame was actually presented. Should be anytime
+    // between the previous task's |markPaintTimingTime| and this task's |taskStartTime|.
+    presentationTime,
+    scripts: [
+        {
+            // This is an imported module or a <script> element
+            // So it includes parsing & evaluation. It may or may not execute code, depending on
+            // the script
+            entryType: "script-block",
+            name: theScriptSrc,
+            initiator: "element" | "import",
+            frameAttribution: TaskAttribution,
+            startTime,
+            duration
+        },
+
+        {
+            entryType: "callback-script",
+
+            frameAttribution: TaskAttribution,
+
+            // these can be classic callbacks, event handlers, or promise resolvers
+            // The name is the object.function of the registration function (the function initially
+            // called to generate this callback).
+            name: "HTMLImgElement.onload" | "Window.requestAnimationFrame" | "Response.json",
+
+            // when the function was invoked
+            startTime,
+            // when the subsequent microtask queue has finished processing
+            duration,
+
+            // The time when the callback was queued, e.g. the event timeStamp.
+            queueTime,
+            // In the case of promise resolver this would be the invoker's source location
+            sourceLocation: "funcName@URL:line:col",
+        }
+    ]
+}
+```
+
+## Some details
+
+### Processing model
+
+The [HTML event loop processing model](https://html.spec.whatwg.org/#event-loop-processing-model)
+can be roughly described as such:
+
+```js
+while (true) {
+    const startTime = performance.now();
+    const task = eventQueue.pop();
+    if (task)
+        task.run();
+    if (performance.now() - startTime > 50)
+        reportLongTask();
+
+    if (hasRenderingOpportunity()) {
+        callFrameAlignedCallbacks(); // e.g. requestAnimationFrame, ResizeObserver
+        markPaintTiming();
+        render();
+    }
+}
+```
+
+The Chromium implementation:
+
+```js
+while (true) {
+    const startTime = performance.now();
+    const task = eventQueue.pop();
+    if (task)
+        task.run();
+    if (performance.now() - startTime > 50)
+        reportLongTask();
+
+    if (hasRenderingOpportunity()) {
+        eventQueue.push(() => {
+            callFrameAlignedCallbacks(); // e.g. requestAnimationFrame, ResizeObserver
+            markPaintTiming();
+            render();
+        });
+    }
+}
+```
+
+The new proposal:
+
+```js
+while (true) {
+    const startTime = performance.now();
+    const task = eventQueue.pop();
+    if (task)
+        task.run();
+
+    if (hasRenderingOpportunity()) {
+        // It doesn't matter if it's a new task...
+        callFrameAlignedCallbacks(); // e.g. requestAnimationFrame, ResizeObserver
+        markPaintTiming();
+
+        // Numbers are bikesheddable
+        if (totalRenderingOpportunities > 3 || performance.now() - startTime > 50)
+            reportLongAnimationFrame();
+        render();
+    }
+}
+```
+
+### Some notes about processing
+
+1. relying on "discarded rendering opportunities" as the qualifier for sluggishness alongside (or
+instead of) millisecond duration allows us to omit noise related to invisible tabs, and also
+doesn't bind us to the notion of a 60hz animations.
+
+1. One complexity inherited from long tasks is the fact that the event loop is shared across
+windows of the same [agent](https://tc39.es/ecma262/#sec-agents) (or process). A possible way to
+mitigate this would be to only report LoAF to a top-level document if it:
+    1. Has been the active document throughout the duration of the long task
+    1. Participates in either the work task or the rendering
+
+
+1. Exposing source locations might be a bit tricky or implementation defined. This can be an optional field but in any case requires some research.
+
+1. Exposing total layout/style time is delicate because those terms are not
+defined and can be quite implementation-specific. However, this info is
+observable today, by calling `getComputedStyle()` which triggers a
+style update or `getClientRects()` which triggers a layout.
+
+## Overlap with [Event Timing](https://w3c.github.io/event-timing/)
+
+With all the new data that LoAFs expose, their overlap with event timing grows. This is true, but it's only a problem if we look at them as separate APIs.
+
+The [dozen-or-so different entry types](https://w3c.github.io/timing-entrytypes-registry/) that go into a performance timeline are not
+separate APIs per-se, but rather queries into the same dataset - the chain of events that helps us understand sluggishness, jank, and instability.
+
+As such, event-timing and LoAF query that dataset differently:
+- event timing is driven by input->feedback, regardless of cause, which
+could be long main thread processing but not necessarily. This is useful to catch regressions in UX for real users without assuming what causes them.
+- LoAF is about catching discarded rendering opportunities. This is a useful
+to diagnose the root cause of high INP or sluggishness.
+
+### in other words
+LoAF measures *cause* and event-timing measures *effect*. Using one to measure the other

--- a/loaf-explainer.md
+++ b/loaf-explainer.md
@@ -176,7 +176,7 @@ while (true) {
 }
 ```
 
-### Some notes about processing
+### Some notes
 
 1. relying on "discarded rendering opportunities" as the qualifier for sluggishness alongside (or
 instead of) millisecond duration allows us to omit noise related to invisible tabs, and also
@@ -195,6 +195,9 @@ mitigate this would be to only report LoAF to a top-level document if it:
 defined and can be quite implementation-specific. However, this info is
 observable today, by calling `getComputedStyle()` which triggers a
 style update or `getClientRects()` which triggers a layout.
+
+1. TBT & TTI are lighthouse values that rely on long tasks. Should they be modified to use long
+animation frames etc?
 
 ## Overlap with [Event Timing](https://w3c.github.io/event-timing/)
 

--- a/loaf-explainer.md
+++ b/loaf-explainer.md
@@ -56,7 +56,7 @@ const someLongAnimationFrameEntry = {
     // This is a well-specified and interoperable time, but doesn't include presentation time
     paintTime,
 
-    duration: markPaintTimingTime - frameStartTime,
+    duration: paintTime - frameStartTime,
 
     // Time spent in style/layout due to JS ("layout thrashing"), e.g. getBoundingClientRect() or
     // getComputedStyle(). This is only taken into account if there is also a layout/style update
@@ -68,7 +68,7 @@ const someLongAnimationFrameEntry = {
     blocking: 'ui-event' | 'animation' | 'none',
 
     // The implementation-specific time when the frame was actually presented. Should be anytime
-    // between the previous task's |markPaintTimingTime| and this task's |taskStartTime|.
+    // between the previous task's |paintTime| and this task's |taskStartTime|.
     presentationTime,
     scripts: [
         {

--- a/loaf-explainer.md
+++ b/loaf-explainer.md
@@ -6,46 +6,123 @@ This is work in progress. Feedback welcome, lots of things might change etc.
 
 ## History
 
-Long tasks have long been a way to diagnose and track lack of responsiveness or "jankiness", which eventually affects core web vital metrics like [INP](https://web.dev/inp/). Developers have been using them with varying degrees of success, and now we can learn from the
+Long tasks have long been a way to diagnose and track lack of responsiveness or "jankiness", which
+eventually affects core web vital metrics like [INP](https://web.dev/inp/), or Lighthouse metrics
+like [Total Blocking Time](https://developer.chrome.com/en/docs/lighthouse/performance/lighthouse-total-blocking-time/).
+Developers have been using them with varying degrees of success, and now we can learn from the
 experience and see what can be improved going forward.
 
 ## Where long tasks fall short
 
-Long tasks rely on the underlying notion of a [task](https://html.spec.whatwg.org/#concept-task). This is a somewhat well-specified term, but we found that it has
-a few shortcomings.
+Long tasks rely on the underlying notion of a [task](https://html.spec.whatwg.org/#concept-task).
+This is a somewhat well-specified term, but we found that it has a few shortcomings:
 
-1. A task does not include the [update the rendering](https://html.spec.whatwg.org/#update-the-rendering) phase. That phase includes `requestAnimationFrame` callbacks,
-resize observers, scroll observers and so on. This means that a lot of the busy time
-that blocks feedback or animation is not actually counted as part of the "long task",
-and developers can game their long task timing by moving long operations into a
-`requestAnimationFrame` callback.
-
-1. A task in implementations is used for internal scheduling, and not just as an
-implementation of the spec concept of task. This means that changes to implementation detail related to scheduling affects the measurement of long tasks, sometimes in
-unexpected, incompatible or arbitrary ways. A big implementation change in chrome silently changed the meaning of long tasks, when we started updating the rendering as part of a new task.
+1. A task does not include the [update the rendering](https://html.spec.whatwg.org/#update-the-rendering)
+phase. That phase includes `requestAnimationFrame` callbacks, resize observers, scroll observers and
+so on. This means that a lot of the busy time that blocks feedback or animation is not actually
+counted as part of the "long task", and developers can game their long task timing by moving long
+operations into a `requestAnimationFrame` callback.
 
 1. Some operations that should be tasks are not specified or implemented to use tasks.
 For example, it is not specified how UI events are integrated into the event loop and
 the use of tasks there is implementation-specific.
 
+1. A task in implementations is used for internal scheduling, and not just as an
+implementation of the spec concept of task. This means that changes to implementation detail related
+to scheduling affects the measurement of long tasks, sometimes in unexpected, incompatible or
+arbitrary ways. A big implementation change in chrome silently changed the meaning of long tasks,
+when we started updating the rendering as part of a new task.
+
 1. A task may contain multiple callbacks, e.g. dispatch several events. This makes
 it sometimes confusing to decipher what was the root cause of a long task.
 
-All of the above are part of the same issue - a task is an incomplete and inaccurate cadence to measure main-thread blocking. It's either too granular (as several tasks together may be the cause of blocking) or too coarse (as it may batch together several event handlers and so on).
+All of the above are part of the same issue - a task is an incomplete and inaccurate cadence to
+measure main-thread blocking. It's either too granular (as several tasks together may be the cause
+of blocking) or too coarse (as it may batch together several event handlers, and callbacks such as
+`requestAnimationFrame` are not tasks in themselves).
+
+### The Current Situation
+
+The [HTML event loop processing model](https://html.spec.whatwg.org/#event-loop-processing-model)
+can be roughly described as such:
+
+```js
+while (true) {
+    const taskStartTime = performance.now();
+    // It's unspecified where UI events fit in. Should each have their own task?
+    const task = eventQueue.pop();
+    if (task)
+        task.run();
+    if (performance.now() - taskStartTime > 50)
+        reportLongTask();
+
+    if (!hasRenderingOpportunity())
+        continue;
+
+    invokeAnimationFrameCallbacks();
+    while (needsStyleAndLayout()) {
+        styleAndLayout();
+        invokeResizeObservers();
+    }
+    markPaintTiming();
+    render();
+}
+```
+
+However, the Chromium implementation is more like this:
+
+```js
+while (true) {
+    const startTime = performance.now();
+    const task = eventQueue.pop();
+    if (task)
+        task.run();
+    uiEventQueue.processEvents({rafAligned: false});
+    if (performance.now() - startTime > 50)
+        reportLongTask();
+
+    if (!hasRenderingOpportunity())
+        continue;
+
+    eventQueue.push(() => {
+        // A new task! so this would report a separate longtask.
+        uiEventQueue.processEvents({rafAligned: true});
+        invokeAnimationFrameCallbacks();
+        while (needsStyleAndLayout()) {
+            styleAndLayout();
+            invokeResizeObservers();
+        }
+        markPaintTiming();
+        render();
+    });
+}
+```
+
 
 ## Introducing LoAF
 
-LoAF (long animation frame) is a new proposed cadence (period of time) and performance entry type, meant to be a progression of the long task concept.
+LoAF (long animation frame) is a new proposed cadence (period of time) and performance entry type,
+meant to be a progression of the long task concept.
 
-It's the time measured between when the main thread started doing any work (see `startTime` [here](https://html.spec.whatwg.org/#event-loop-processing-model)), until it is [ready to paint](https://html.spec.whatwg.org/#event-loop-processing-model:mark-paint-timing). It may include several tasks (e.g. a few short ones and then a long one). Because it ends at the paint-mark time, it
-includes all the rendering obsevers (requestAnimationFrame, ResizeObserver etc.) and
-may or may not include presentation time (as that is somewhat implementation specific).
+It's the time measured between when the main thread started doing any work (see `startTime`
+[here](https://html.spec.whatwg.org/#event-loop-processing-model)), until it is either
+[ready to paint](https://html.spec.whatwg.org/#event-loop-processing-model:mark-paint-timing) or
+idle (has nothing to do). It may include more than one task, though usually up to 2. Because it ends
+at the paint-mark time, it includes all the rendering obsevers
+(requestAnimationFrame, ResizeObserver etc.) and may or may not include presentation time
+(as that is somewhat implementation specific).
 
-In addition to making the cadence fit better with what it measures, the entry could include extra information to help understand what made it long, and what kind of consequences it had:
+In addition to making the cadence fit better with what it measures, the entry could include extra
+information to help understand what made it long, and what kind of consequences it had:
 
-- Time spent in forced layout/style calculations - e.g. calling `getBoundingClientRect`, doing more processing, and then rendering (also known as "layout thrashing" or "forced reflow").
-- Is the frame blocking input-feedback *in practice*. Note that a frame that blocks actual UI events would also be accessible via [event timing](https://w3c.github.io/event-timing/).
-- User scripts processed during the time of the frame, be it callbacks, event handlers, promise resolvers, or script block parsing and evaluation, and information about those scripts (source, how long they've been delayed for).
+- Time spent in the different phases (rendering, layout-and-style).
+- Time spent in forced layout/style calculations - e.g. calling `getBoundingClientRect`, doing more
+processing, and then rendering (also known as "layout thrashing" or "forced reflow").
+- Is the frame blocking input-feedback *in practice*. Note that a frame that blocks actual UI event
+ would also be accessible via [event timing](https://w3c.github.io/event-timing/).
+- User scripts processed during the time of the frame, be it callbacks, event handlers, promise
+resolvers, or script block parsing and evaluation, and information about those scripts (source, how
+long they've been delayed for).
 
 ## How a LoAF entry might look like
 ```js
@@ -57,9 +134,9 @@ const someLongAnimationFrameEntry = {
 
     // https://html.spec.whatwg.org/#event-loop-processing-model (17)
     // This is a well-specified and interoperable time, but doesn't include presentation time
-    paintTime,
+    renderEndTime,
 
-    duration: paintTime - frameStartTime,
+    duration: renderEnd - frameStartTime,
 
     // Time spent in style/layout due to JS ("layout thrashing"), e.g. getBoundingClientRect() or
     // getComputedStyle(). This is only taken into account if there is also a layout/style update
@@ -84,11 +161,12 @@ const someLongAnimationFrameEntry = {
             // This is an imported module or a <script> element
             // So it includes parsing & evaluation. It may or may not execute code, depending on
             // the script
-            entryType: "script-block",
+            entryType: "evaluate-script",
             name: theScriptSrc,
             initiator: "element" | "import",
-            frameAttribution: TaskAttribution,
             startTime,
+            // The time after parse+compile
+            executionStartTime,
             duration
         },
 
@@ -116,53 +194,7 @@ const someLongAnimationFrameEntry = {
 }
 ```
 
-## Some details
-
 ### Processing model
-
-The [HTML event loop processing model](https://html.spec.whatwg.org/#event-loop-processing-model)
-can be roughly described as such:
-
-```js
-while (true) {
-    const startTime = performance.now();
-    // It's unspecified where UI events fit in. Does each have their own task?
-    const task = eventQueue.pop();
-    if (task)
-        task.run();
-    if (performance.now() - startTime > 50)
-        reportLongTask();
-
-    if (hasRenderingOpportunity()) {
-        callFrameAlignedCallbacks(); // e.g. requestAnimationFrame, ResizeObserver
-        markPaintTiming();
-        render();
-    }
-}
-```
-
-The Chromium implementation:
-
-```js
-while (true) {
-    const startTime = performance.now();
-    const task = eventQueue.pop();
-    if (task)
-        task.run();
-    uiEventQueue.processEvents({rafAligned: false});
-    if (performance.now() - startTime > 50)
-        reportLongTask();
-
-    if (hasRenderingOpportunity()) {
-        eventQueue.push(() => {
-            uiEventQueue.processEvents({rafAligned: true});
-            callFrameAlignedCallbacks(); // e.g. requestAnimationFrame, ResizeObserver
-            markPaintTiming();
-            render();
-        });
-    }
-}
-```
 
 The new proposal:
 
@@ -179,50 +211,52 @@ while (true) {
     if (task)
         task.run();
 
-    if (hasRenderingOpportunity()) {
-        // It doesn't matter if it's a new task...
-        if (document.needsToRender()) {
-            invokeAnimationFrameCallbacks();
-            frameTiming.styleAndLayoutStart = performance.now();
-            while (document.needsStyleOrLayout()) {
-                document.calculateStyleAndLayout();
-                invokeResizeObserverCallbacks();
-            }
-            frameTiming.paintTime = performance.now();
-            markPaintTiming();
-
-            // Maybe also count discarded render opportunities, or change the magic number
-            if (performance.now() - frameStartTime > 50)
-                reportLongAnimationFrame();
-            render();
-        }
-
-        // Next event loop iteration would reinitialize frameStartTime.
-        frameStartTime = null;
+    if (!hasDocumentThatNeedsRender()) {
+        frameTiming.renderEnd = performance.now();
+        if (frameTiming.renderEnd - frameStartTime > 50)
+            reportLongAnimationFrame();
     }
+
+    if (!hasRenderingOpportunity())
+        continue;
+
+    invokeAnimationFrameCallbacks();
+    frameTiming.styleAndLayoutStart = performance.now();
+    while (document.needsStyleOrLayout()) {
+        document.calculateStyleAndLayout();
+        invokeResizeObserverCallbacks();
+    }
+    frameTiming.renderEnd = performance.now();
+    markPaintTiming();
+    if (frameTiming.renderEnd - frameStartTime > 50)
+        reportLongAnimationFrame();
+
+    render();
 }
 ```
 
 ### Notes, complexity, doubts, future ideas
 
 1. One complexity inherited from long tasks is the fact that the event loop is shared across
-windows of the same [agent](https://tc39.es/ecma262/#sec-agents) (or process). A possible way to
-mitigate this would be to only report LoAF to a top-level document if it:
-    1. Has been the active document throughout the duration of the long task
-    1. Participates in either the work task or the rendering
+windows of the same [agent](https://tc39.es/ecma262/#sec-agents) (or process). The solution here is
+a bit different but relies on similar principles:
+
+    1. Only frames in visible pages report long frames.
+
+    1. An observer fires only if its rendering was blocked by the long frame in practice, or if
+    the long task (that didn't cause a render) belonged to that page.
+
+    1. Breakdown to scripts is only available to the frame where they were invoked. Other frames
+    receive an "opaque" breakdown: attribution of a blocking task to a different window - similar to
+    the existing [attribution](https://w3c.github.io/longtasks/#sec-TaskAttributionTiming).
 
 
-1. we might consider in the future to relyi on "discarded rendering opportunities" as the qualifier
-for sluggishness alongside (or instead of) millisecond duration allows us to omit noise related to
-invisible tabs, and also doesn't bind us to the notion of a 60hz animations.
+1. To avoid the magic 50hz number, we might consider in the future to make the threshold configurable,
+or rely on "discarded rendering opportunities" as the qualifier for sluggishness alongside (or
+instead of) millisecond duration.
 
 1. Exposing source locations might be a bit tricky or implementation defined.
 This can be an optional field but in any case requires some research.
-
-1. Exposing total layout/style time is delicate because those terms are not
-defined and can be quite implementation-specific. However, this info is
-observable today, by calling `getComputedStyle()` which triggers a
-style update or `getClientRects()` which triggers a layout.
 
 1. TBT & TTI are lighthouse values that rely on long tasks. Should they be modified to use LoAFs
 instead? Are those metrics useful?
@@ -239,6 +273,3 @@ As such, event-timing and LoAF query that dataset differently:
 could be long main thread processing but not necessarily. This is useful to catch regressions in UX for real users without assuming what causes them.
 - LoAF is about catching discarded rendering opportunities. This is a useful
 to diagnose the root cause of high INP or sluggishness.
-
-### in other words
-LoAF measures *cause* and event-timing measures *effect*. Using one to measure the other

--- a/loaf-explainer.md
+++ b/loaf-explainer.md
@@ -140,11 +140,6 @@ const someLongAnimationFrameEntry = {
     // and all that's left is painting & compositing.
     duration,
 
-    // Whether this long frame was blocking input/animation in practice
-    // A LOaF can block both, in which case ui-event would take precedent.
-    // (Not implemented yet)
-    blocking: 'ui-event' | 'animation' | 'none',
-
     // https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering
     // The time where the rendering cycle has started. The rendering cycle includes
     // requestAnimationFrame callbacks, style and layout calculation, resize observer and

--- a/loaf-explainer.md
+++ b/loaf-explainer.md
@@ -290,14 +290,14 @@ At the most part, LoAF only exposes information across same-origin windows. Info
 scripts within a window is already observable, e.g. using resource timing or a service worker.
 
 However, LoAF might expose rendering information for a particular document tree that may be
-cross-origin (same-agent/site). The details about rendering the frame, such as
+cross-origin (same-agent). The details about rendering the frame, such as
 `styleAndLayoutStartTime`, are proposed to be visible to all the same-agent windows that are
 rendered serially. That's because this information is already observable, by using
 `requestAnimationFrame` and `ResizeObserver` and measuring the delay between them. The premise is
 that global "update the rendering" timing information is already observable across same-agent
 windows, so exposing it directly does not leak new cross-origin information. However, the idea
-exposing less information to cross-origin same-agent subframes (as in, expose ) is open for
-discussion.
+exposing less information to cross-origin same-agent subframes (as in, expose the rendering info
+only to the main frame) is open for discussion.
 
 ### Notes, complexity, doubts, future ideas, TODOs
 
@@ -315,7 +315,7 @@ a bit different but relies on similar principles:
     the existing [attribution](https://w3c.github.io/longtasks/#sec-TaskAttributionTiming).
 
 
-1. To avoid the magic 50hz number, consider making the threshold configurable,
+1. To avoid the magic 50ms number, consider making the threshold configurable,
 or rely on "discarded rendering opportunities" as the qualifier for sluggishness alongside (or
 instead of) millisecond duration.
 

--- a/loaf-explainer.md
+++ b/loaf-explainer.md
@@ -136,22 +136,12 @@ const someLongAnimationFrameEntry = {
     // This is a well-specified and interoperable time, but doesn't include presentation time.
     // It's the time after all the animations and observers are done, style and layout are done,
     // and all that's left is painting & compositing.
-    renderEndTime,
-
-    duration: renderEnd - frameStartTime,
-
-    // Time spent in style/layout due to JS ("layout thrashing"), e.g. getBoundingClientRect() or
-    // getComputedStyle(). This is only taken into account if there is also a layout/style update
-    // in the final rendering phase.
-    totalForcedStyleAndLayoutDuration,
+    duration,
 
     // Whether this long frame was blocking input/animation in practice
     // A LOaF can block both, in which case ui-event would take precedent.
+    // (Not implemented yet)
     blocking: 'ui-event' | 'animation' | 'none',
-
-    // Whether the work task (before rendering) cane from this window, a descendant, an ancestor,
-    // or adifferent window
-    taskAttribution: TaskAttributionTiming
 
     // https://html.spec.whatwg.org/#update-the-rendering
     renderStart,
@@ -159,13 +149,22 @@ const someLongAnimationFrameEntry = {
     // https://html.spec.whatwg.org/#update-the-rendering (#14)
     styleAndLayoutStart,
 
+    // The time the animation frame was queued. This could be before startTime, which means that
+    // the animation frame was delayed, or after, which means that it was deferred - several updates
+    // were batched together before scheduling a frame.
+    desiredRenderStart,
+
     // The implementation-specific time when the frame was actually presented. Should be anytime
     // between the previous task's |paintTime| and this task's |taskStartTime|.
+    // (Not implemented yet)
     presentationTime,
+
+    // Time of the first UI event (mouse/keyboard etc.)
+    firstUIEventTimestamp,
     scripts: [
         {
-            entryType: "callback" | "promise" | "classic-script" | "dynamic-module-import" |
-                        "module-script" | ""
+            type: "user-callback" | "classic-script" |
+                        "module-script" | "event-listener" | "resolve-promise" | "reject-promise"
 
             // these can be classic callbacks, event handlers, or promise resolvers
             // The name is the object.function of the registration function (the function initially
@@ -177,21 +176,29 @@ const someLongAnimationFrameEntry = {
 
             // If this script was parsed/compiled, this would be the time after compilation.
             // Otherwise it would be equal to startTime
-            executionStartTime,
+            executionStart,
 
             // the duration between startTime and when the subsequent microtask queue has finished
             // processing
             duration,
 
             // Total time spent in forced layout/style inside this function
-            forcedStyleAndLayoutTime,
+            forcedStyleAndLayoutDuration,
 
             // The time when the callback was queued, e.g. the event timeStamp or the time when
             // the timeout was supposed to be invoked.
-            queueTime,
+            desiredExecutionStart,
 
             // In the case of promise resolver this would be the invoker's source location
             sourceLocation: "functionName@URL:line:col",
+
+            // Relationship between the (same-origin) window where this script was executed and
+            // this window.
+            windowAttribution: "self" | "descendant" | "ancestor" | "same-page" | "other"
+
+            // A reference to the same-origin window that originated the script, if it's still
+            // alive.
+            window,
         }
     ]
 }

--- a/loaf-explainer.md
+++ b/loaf-explainer.md
@@ -1,6 +1,9 @@
 # Long Animation Frames (LoAF)
 Long Tasks Revamped
 
+## Diclaimer
+This is work in progress. Feedback welcome, early for expectations :)
+
 ## History
 
 Long tasks have long been a way to diagnose and track lack of responsiveness or "jankiness", which eventually affects core web vital metrics like [INP](https://web.dev/inp/). Developers have been using them with varying degrees of success, and now we can learn from the


### PR DESCRIPTION
Add explainer for long-task revamp

See https://github.com/w3c/event-timing/issues/122 and https://github.com/w3c/longtasks/issues/89